### PR TITLE
usb: Add reset, power features

### DIFF
--- a/include/zephyr/usb/class/usb_hub.h
+++ b/include/zephyr/usb/class/usb_hub.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 Emerson Electric Co.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief USB Hub Class device API header
+ */
+
+#ifndef ZEPHYR_INCLUDE_USB_CLASS_USB_HUB_H_
+#define ZEPHYR_INCLUDE_USB_CLASS_USB_HUB_H_
+
+/** USB Hub Class Feature Selectors defined in spec. Table 11-17 */
+#define USB_HCFS_C_HUB_LOCAL_POWER	0x00
+#define USB_HCFS_C_HUB_OVER_CURRENT	0x01
+#define USB_HCFS_PORT_CONNECTION	0x00
+#define USB_HCFS_PORT_ENABLE		0x01
+#define USB_HCFS_PORT_SUSPEND		0x02
+#define USB_HCFS_PORT_OVER_CURRENT	0x03
+#define USB_HCFS_PORT_RESET		0x04
+#define USB_HCFS_PORT_POWER		0x08
+#define USB_HCFS_PORT_LOW_SPEED		0x09
+#define USB_HCFS_C_PORT_CONNECTION	0x10
+#define USB_HCFS_C_PORT_ENABLE		0x11
+#define USB_HCFS_C_PORT_SUSPEND		0x12
+#define USB_HCFS_C_PORT_OVER_CURRENT	0x13
+#define USB_HCFS_C_PORT_RESET		0x14
+#define USB_HCFS_PORT_TEST		0x15
+#define USB_HCFS_PORT_INDICATOR		0x16
+
+/** USB Hub Class Request Codes defined in spec. Table 11-16 */
+#define USB_HCREQ_GET_STATUS		0x00
+#define USB_HCREQ_CLEAR_FEATURE		0x01
+#define USB_HCREQ_SET_FEATURE		0x03
+#define USB_HCREQ_GET_DESCRIPTOR	0x06
+#define USB_HCREQ_SET_DESCRIPTOR	0x07
+#define USB_HCREQ_CLEAR_TT_BUFFER	0x08
+#define USB_HCREQ_RESET_TT		0x09
+#define USB_HCREQ_GET_TT_STATE		0x0A
+#define USB_HCREQ_STOP_TT		0x0B
+
+#endif /* ZEPHYR_INCLUDE_USB_CLASS_USB_HUB_H_ */

--- a/include/zephyr/usb/usb_ch9.h
+++ b/include/zephyr/usb/usb_ch9.h
@@ -14,6 +14,7 @@
 
 #include <version.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/usb/class/usb_hub.h>
 
 #ifndef ZEPHYR_INCLUDE_USB_CH9_H_
 #define ZEPHYR_INCLUDE_USB_CH9_H_

--- a/subsys/usb/host/usbh_ch9.c
+++ b/subsys/usb/host/usbh_ch9.c
@@ -170,3 +170,33 @@ int usbh_req_clear_sfs_rwup(const struct device *dev,
 			      bmRequestType, bRequest, wValue, 0, 0,
 			      NULL);
 }
+
+int usbh_req_set_hcfs_ppwr(const struct device *dev,
+			   const uint8_t addr, const uint8_t port)
+{
+	const uint8_t bmRequestType = USB_REQTYPE_DIR_TO_DEVICE << 7 |
+	                              USB_REQTYPE_TYPE_CLASS << 5 |
+	                              USB_REQTYPE_RECIPIENT_OTHER << 0;
+	const uint8_t bRequest = USB_HCREQ_SET_FEATURE;
+	const uint16_t wValue = USB_HCFS_PORT_POWER;
+	const uint16_t wIndex = port;
+
+	return usbh_req_setup(dev, addr,
+			      bmRequestType, bRequest, wValue, wIndex, 0,
+			      NULL);
+}
+
+int usbh_req_set_hcfs_prst(const struct device *dev,
+			   const uint8_t addr, const uint8_t port)
+{
+	const uint8_t bmRequestType = USB_REQTYPE_DIR_TO_DEVICE << 7 |
+	                              USB_REQTYPE_TYPE_CLASS << 5 |
+	                              USB_REQTYPE_RECIPIENT_OTHER << 0;
+	const uint8_t bRequest = USB_HCREQ_SET_FEATURE;
+	const uint16_t wValue = USB_HCFS_PORT_RESET;
+	const uint16_t wIndex = port;
+
+	return usbh_req_setup(dev, addr,
+			      bmRequestType, bRequest, wValue, wIndex, 0,
+			      NULL);
+}

--- a/subsys/usb/host/usbh_ch9.h
+++ b/subsys/usb/host/usbh_ch9.h
@@ -49,4 +49,10 @@ int usbh_req_set_sfs_rwup(const struct device *dev,
 int usbh_req_clear_sfs_rwup(const struct device *dev,
 			    const uint8_t addr);
 
+int usbh_req_set_hcfs_ppwr(const struct device *dev,
+			   const uint8_t addr, const uint8_t port);
+
+int usbh_req_set_hcfs_prst(const struct device *dev,
+			   const uint8_t addr, const uint8_t port);
+
 #endif /* ZEPHYR_INCLUDE_USBH_CH9_H */

--- a/subsys/usb/host/usbh_shell.c
+++ b/subsys/usb/host/usbh_shell.c
@@ -300,6 +300,48 @@ static int cmd_feature_set_rwup(const struct shell *sh,
 	return err;
 }
 
+static int cmd_feature_set_ppwr(const struct shell *sh,
+				size_t argc, char **argv)
+{
+	uint8_t addr;
+	uint8_t port;
+	int err;
+
+	addr = strtol(argv[1], NULL, 10);
+	port = strtol(argv[2], NULL, 10);
+
+	err = usbh_req_set_hcfs_ppwr(uhs_ctx.dev, addr, port);
+	if (err) {
+		shell_error(sh, "host: Failed to set ppwr feature");
+	} else {
+		shell_print(sh, "host: Device 0x%02x, port %d, ppwr feature set",
+			    addr, port);
+	}
+
+	return err;
+}
+
+static int cmd_feature_set_prst(const struct shell *sh,
+				size_t argc, char **argv)
+{
+	uint8_t addr;
+	uint8_t port;
+	int err;
+
+	addr = strtol(argv[1], NULL, 10);
+	port = strtol(argv[2], NULL, 10);
+
+	err = usbh_req_set_hcfs_prst(uhs_ctx.dev, addr, port);
+	if (err) {
+		shell_error(sh, "host: Failed to set prst feature");
+	} else {
+		shell_print(sh, "host: Device 0x%02x, port %d, prst feature set",
+			    addr, port);
+	}
+
+	return err;
+}
+
 static int cmd_device_config(const struct shell *sh,
 			     size_t argc, char **argv)
 {
@@ -479,6 +521,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(desc_cmds,
 SHELL_STATIC_SUBCMD_SET_CREATE(feature_set_cmds,
 	SHELL_CMD_ARG(rwup, NULL, "<address>",
 		      cmd_feature_set_rwup, 2, 0),
+	SHELL_CMD_ARG(ppwr, NULL, "<address> <port>",
+		      cmd_feature_set_ppwr, 3, 0),
+	SHELL_CMD_ARG(prst, NULL, "<address> <port>",
+		      cmd_feature_set_prst, 3, 0),
 	SHELL_CMD_ARG(halt, NULL, "<address> <endpoint>",
 		      cmd_feature_set_halt, 3, 0),
 	SHELL_SUBCMD_SET_END


### PR DESCRIPTION
This adds PORT_RESET and PORT_POWER USB hub features. Within the shell, it allows the foobaz device to be behind a hub.