### PR TITLE
drivers: udc_dwc2: prevent access to registers if USBHS is not ready

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -237,3 +237,7 @@ ipc0: &cpuapp_cpurad_ipc {
 &cpuapp_ieee802154 {
 	status = "okay";
 };
+
+zephyr_udc0: &usbhs {
+	status = "okay";
+};

--- a/drivers/usb/udc/Kconfig.dwc2
+++ b/drivers/usb/udc/Kconfig.dwc2
@@ -5,6 +5,8 @@ config UDC_DWC2
 	bool "DWC2 USB device controller driver"
 	default y
 	depends on DT_HAS_SNPS_DWC2_ENABLED
+	select NRFS if NRFS_HAS_VBUS_DETECTOR_SERVICE
+	select NRFS_VBUS_DETECTOR_SERVICE_ENABLED if NRFS_HAS_VBUS_DETECTOR_SERVICE
 	help
 	  DWC2 USB device controller driver.
 

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -69,7 +69,7 @@ struct udc_dwc2_data {
 	uint32_t max_pktcnt;
 	uint32_t tx_len[16];
 	unsigned int dynfifosizing : 1;
-	/* Number of endpoints in addition to control endpoint */
+	/* Number of endpoints including control endpoint */
 	uint8_t numdeveps;
 	/* Number of IN endpoints including control endpoint */
 	uint8_t ineps;
@@ -948,7 +948,7 @@ static void dwc2_unset_unused_fifo(const struct device *dev)
 	struct udc_dwc2_data *const priv = udc_get_private(dev);
 	struct udc_ep_config *tmp;
 
-	for (uint8_t i = priv->ineps; i > 0; i--) {
+	for (uint8_t i = priv->ineps - 1U; i > 0; i--) {
 		tmp = udc_get_ep_cfg(dev, i | USB_EP_DIR_IN);
 
 		if (tmp->stat.enabled && (priv->txf_set & BIT(i))) {
@@ -1396,10 +1396,10 @@ static int udc_dwc2_init_controller(const struct device *dev)
 	}
 
 	/* Get the number or endpoints and IN endpoints we can use later */
-	priv->numdeveps = usb_dwc2_get_ghwcfg2_numdeveps(ghwcfg2);
-	priv->ineps = usb_dwc2_get_ghwcfg4_ineps(ghwcfg4);
-	LOG_DBG("Number of endpoints (NUMDEVEPS) %u", priv->numdeveps);
-	LOG_DBG("Number of IN endpoints (INEPS) %u", priv->ineps);
+	priv->numdeveps = usb_dwc2_get_ghwcfg2_numdeveps(ghwcfg2) + 1U;
+	priv->ineps = usb_dwc2_get_ghwcfg4_ineps(ghwcfg4) + 1U;
+	LOG_DBG("Number of endpoints (NUMDEVEPS + 1) %u", priv->numdeveps);
+	LOG_DBG("Number of IN endpoints (INEPS + 1) %u", priv->ineps);
 
 	LOG_DBG("Number of periodic IN endpoints (NUMDEVPERIOEPS) %u",
 		usb_dwc2_get_ghwcfg4_numdevperioeps(ghwcfg4));

--- a/drivers/usb/udc/udc_dwc2_vendor_quirks.h
+++ b/drivers/usb/udc/udc_dwc2_vendor_quirks.h
@@ -11,6 +11,7 @@
 
 #include <stdint.h>
 #include <zephyr/device.h>
+#include <zephyr/drivers/usb/udc.h>
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_fsotg)
 
@@ -106,6 +107,142 @@ DT_INST_FOREACH_STATUS_OKAY(QUIRK_STM32F4_FSOTG_DEFINE)
 #undef DT_DRV_COMPAT
 
 #endif /*DT_HAS_COMPAT_STATUS_OKAY(st_stm32f4_fsotg) */
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_usbhs)
+
+#define DT_DRV_COMPAT snps_dwc2
+
+#include <nrfs_backend_ipc_service.h>
+#include <nrfs_usb.h>
+
+#define USBHS_DT_WRAPPER_REG_ADDR(n) UINT_TO_POINTER(DT_INST_REG_ADDR_BY_NAME(n, wrapper))
+
+static void usbhs_vbus_handler(nrfs_usb_evt_t const *p_evt, void *const context)
+{
+	const struct device *dev = context;
+
+	switch (p_evt->type) {
+	case NRFS_USB_EVT_VBUS_STATUS_CHANGE:
+		LOG_DBG("USBHS new status, pll_ok = %d vreg_ok = %d vbus_detected = %d",
+			p_evt->usbhspll_ok, p_evt->vregusb_ok, p_evt->vbus_detected);
+
+		if (p_evt->usbhspll_ok && p_evt->vregusb_ok && p_evt->vbus_detected) {
+			udc_submit_event(dev, UDC_EVT_VBUS_READY, 0);
+		} else {
+			udc_submit_event(dev, UDC_EVT_VBUS_REMOVED, 0);
+		}
+
+		break;
+	case NRFS_USB_EVT_REJECT:
+		LOG_ERR("Request rejected");
+		break;
+	default:
+		LOG_ERR("Unknown event type 0x%x", p_evt->type);
+		break;
+	}
+}
+
+static inline int usbhs_enable_nrfs_service(const struct device *dev)
+{
+	nrfs_err_t nrfs_err;
+	int err;
+
+	err = nrfs_backend_wait_for_connection(K_MSEC(1000));
+	if (err) {
+		LOG_INF("NRFS backend connection timeout");
+		return err;
+	}
+
+	nrfs_err = nrfs_usb_init(usbhs_vbus_handler);
+	if (nrfs_err != NRFS_SUCCESS) {
+		LOG_ERR("Failed to init NRFS VBUS handler: %d", nrfs_err);
+		return -EIO;
+	}
+
+	nrfs_err = nrfs_usb_enable_request((void *)dev);
+	if (nrfs_err != NRFS_SUCCESS) {
+		LOG_ERR("Failed to enable NRFS VBUS service: %d", nrfs_err);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static inline int usbhs_enable_core(const struct device *dev)
+{
+	NRF_USBHS_Type *wrapper = USBHS_DT_WRAPPER_REG_ADDR(0);
+
+	wrapper->ENABLE = USBHS_ENABLE_PHY_Msk | USBHS_ENABLE_CORE_Msk;
+	wrapper->TASKS_START = 1UL;
+
+	/* Enable interrupt */
+	wrapper->INTENSET = 1UL;
+
+	return 0;
+}
+
+static inline int usbhs_disable_core(const struct device *dev)
+{
+	NRF_USBHS_Type *wrapper = USBHS_DT_WRAPPER_REG_ADDR(0);
+
+	wrapper->ENABLE = 0UL;
+	wrapper->TASKS_START = 1UL;
+
+	/* Enable interrupt */
+	wrapper->INTENSET = 0UL;
+
+	return 0;
+}
+
+static inline int usbhs_disable_nrfs_service(const struct device *dev)
+{
+	nrfs_err_t nrfs_err;
+
+	nrfs_err = nrfs_usb_disable_request((void *)dev);
+	if (nrfs_err != NRFS_SUCCESS) {
+		LOG_ERR("Failed to disable NRFS VBUS service: %d", nrfs_err);
+		return -EIO;
+	}
+
+	nrfs_usb_uninit();
+
+	return 0;
+}
+
+static inline int usbhs_irq_clear(const struct device *dev)
+{
+	NRF_USBHS_Type *wrapper = USBHS_DT_WRAPPER_REG_ADDR(0);
+
+	wrapper->EVENTS_CORE = 0UL;
+
+	return 0;
+}
+
+static inline int usbhs_init_caps(const struct device *dev)
+{
+	struct udc_data *data = dev->data;
+
+	data->caps.can_detect_vbus = true;
+	data->caps.hs = true;
+
+	return 0;
+}
+
+#define QUIRK_NRF_USBHS_DEFINE(n)						\
+	struct dwc2_vendor_quirks dwc2_vendor_quirks_##n = {			\
+		.init = usbhs_enable_nrfs_service,				\
+		.pre_enable = usbhs_enable_core,				\
+		.disable = usbhs_disable_core,					\
+		.shutdown = usbhs_disable_nrfs_service,				\
+		.irq_clear = usbhs_irq_clear,					\
+		.caps = usbhs_init_caps,					\
+	};
+
+DT_INST_FOREACH_STATUS_OKAY(QUIRK_NRF_USBHS_DEFINE)
+
+#undef DT_DRV_COMPAT
+
+#endif /*DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_usbhs) */
 
 /* Add next vendor quirks definition above this line */
 

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -333,10 +333,15 @@
 			ranges = <0x0 0x5f000000 0x1000000>;
 
 			usbhs: usbhs@86000 {
-				compatible = "snps,dwc2";
+				compatible = "nordic,nrf-usbhs", "snps,dwc2";
 				reg = <0x86000 0x1000>, <0x2f700000 0x40000>;
 				reg-names = "wrapper", "core";
 				interrupts = <134 NRF_DEFAULT_IRQ_PRIORITY>;
+				num-in-eps = <8>;
+				num-out-eps = <10>;
+				ghwcfg1 = <0xaa555000>;
+				ghwcfg2 = <0x22abfc72>;
+				ghwcfg4 = <0x1e10aa60>;
 				status = "disabled";
 			};
 


### PR DESCRIPTION
On USBHS, we cannot access the DWC2 register until VBUS is detected and valid. Kernel event API is used to block if a valid VBUS signal is not present when the user tries to force usbd_enable().