### PR TITLE
drivers: udc_dwc2: Execute disable in driver thread

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -42,6 +42,8 @@ enum dwc2_drv_event_type {
 	DWC2_DRV_EVT_HIBERNATION_EXIT_BUS_RESET,
 	/* Core should exit hibernation due to host resume */
 	DWC2_DRV_EVT_HIBERNATION_EXIT_HOST_RESUME,
+	/* Driver thread should disable core and cease all register accesses */
+	DWC2_DRV_EVT_DISABLE,
 };
 
 /* Minimum RX FIFO size in 32-bit words considering the largest used OUT packet
@@ -2038,7 +2040,7 @@ static int udc_dwc2_enable(const struct device *dev)
 	return 0;
 }
 
-static int udc_dwc2_disable(const struct device *dev)
+static int dwc2_handle_disable(const struct device *dev)
 {
 	const struct udc_dwc2_config *const config = dev->config;
 	struct udc_ep_config *cfg_out = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
@@ -2061,7 +2063,6 @@ static int udc_dwc2_disable(const struct device *dev)
 	}
 
 	config->irq_disable_func(dev);
-	cancel_hibernation_request(priv);
 
 	if (priv->hibernated) {
 		dwc2_exit_hibernation(dev, false, true);
@@ -2092,6 +2093,27 @@ static int udc_dwc2_disable(const struct device *dev)
 	}
 
 	return 0;
+}
+
+static int udc_dwc2_disable(const struct device *dev)
+{
+	struct udc_dwc2_data *const priv = udc_get_private(dev);
+	struct udc_data *data = dev->data;
+
+	/* Avoid context switch immediately after posting event */
+	k_sched_lock();
+
+	/* Inform driver thread that we want to disable */
+	k_event_post(&priv->drv_evt, BIT(DWC2_DRV_EVT_DISABLE));
+
+	/* Wait for driver thread to disable core, UDC mutex was acquired via
+	 * api->lock() called in udc_disable().
+	 */
+	k_condvar_wait(&priv->core_disabled, &data->mutex, K_FOREVER);
+
+	k_sched_unlock();
+
+	return priv->disable_status;
 }
 
 static int udc_dwc2_init(const struct device *dev)
@@ -2134,6 +2156,7 @@ static int dwc2_driver_preinit(const struct device *dev)
 
 	k_mutex_init(&data->mutex);
 
+	k_condvar_init(&priv->core_disabled);
 	k_event_init(&priv->drv_evt);
 	atomic_clear(&priv->xfer_new);
 	atomic_clear(&priv->xfer_finished);
@@ -3166,6 +3189,20 @@ static ALWAYS_INLINE void dwc2_thread_handler(void *const arg)
 
 	if (evt & BIT(DWC2_DRV_EVT_ENUM_DONE)) {
 		k_event_clear(&priv->drv_evt, BIT(DWC2_DRV_EVT_ENUM_DONE));
+	}
+
+	if (evt & BIT(DWC2_DRV_EVT_DISABLE)) {
+		priv->disable_status = dwc2_handle_disable(dev);
+
+		if (priv->disable_status == 0) {
+			/* Driver is disabled, cease all register accesses */
+			k_event_clear(&priv->drv_evt, UINT32_MAX);
+		} else {
+			k_event_clear(&priv->drv_evt, BIT(DWC2_DRV_EVT_DISABLE));
+		}
+
+		/* Notify requestors that core is now disabled */
+		k_condvar_broadcast(&priv->core_disabled);
 	}
 
 	udc_unlock_internal(dev);

--- a/drivers/usb/udc/udc_dwc2.h
+++ b/drivers/usb/udc/udc_dwc2.h
@@ -79,6 +79,8 @@ struct udc_dwc2_data {
 	DEVICE_MMIO_NAMED_RAM(core);
 	struct k_spinlock lock;
 	struct k_thread thread_data;
+	/* Condition variable used to synchronously disable in driver thread */
+	struct k_condvar core_disabled;
 	/* Main events the driver thread waits for */
 	struct k_event drv_evt;
 	/* Endpoint is considered disabled when there is no active transfer */
@@ -95,6 +97,8 @@ struct udc_dwc2_data {
 	uint32_t rx_siz[16];
 	/* Isochronous endpoint enabled (IN on bits 0-15, OUT on bits 16-31) */
 	uint32_t iso_enabled;
+	/* Return code from disable executed synchronously in driver thread */
+	int disable_status;
 	uint16_t iso_in_rearm;
 	uint16_t iso_out_rearm;
 	uint16_t ep_out_disable;


### PR DESCRIPTION
After DWC2 core is disabled the registers should no longer be accessed to prevent CPU hangs. While the concurrent access is guarded by mutex, there was no mechanism to ensure that driver thread won't access any register after udc_disable() was called. Solve the issue by executing disable in driver thread context.